### PR TITLE
Use Edge runtime instead of Node.js runtime for 404 page

### DIFF
--- a/frontend/app/(portal)/[...not_found]/page.jsx
+++ b/frontend/app/(portal)/[...not_found]/page.jsx
@@ -1,3 +1,12 @@
+// In Next.js, when you're using Cloudflare Pages or other platforms that
+// leverage Edge functions, you need to tell Next.js which routes should
+// run in the Edge Runtime instead of the Node.js Runtime. By default, Next.js
+// assumes that certain dynamic server-side routes are handled by Node.js.
+// However, on platforms like Cloudflare Pages, which use Edge functions to
+// handle requests, you need to explicitly configure these routes to be
+// compatible with the Edge Runtime.
+export const runtime = 'edge'; // Tell Next.js to use the Edge Runtime for this route instead of the Node.js Runtime
+
 import {notFound} from "next/navigation"
 
 export default function NotFoundCatchAll() {


### PR DESCRIPTION
## Issue:
Cannot build the 404 page on Cloudflare Pages

<img width="350" alt="PNG image" src="https://github.com/user-attachments/assets/aa65df29-dd2e-4c04-bf0a-0d285ef48086">

## How to fix it:
Tell Next.js to use the Edge Runtime for this [dynamic route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes) instead of the default Node.js Runtime by adding this line:

```js
export const runtime = 'edge'; // Add this line

import {notFound} from "next/navigation"

export default function NotFoundCatchAll() {
  notFound()
}
```

## Why:

In Next.js, when you're using Cloudflare Pages or other platforms that leverage Edge functions, you need to tell Next.js which routes should run in the Edge Runtime instead of the Node.js Runtime. By default, Next.js assumes that certain dynamic server-side routes are handled by Node.js. However, on platforms like Cloudflare Pages, which use Edge functions to handle requests, you need to explicitly configure these routes to be compatible with the Edge Runtime.

### Edge Runtime vs. Node.js Runtime:

#### Node.js Runtime:
- Traditional server-side execution environment.
- Typically used for server-side rendering (SSR) and API routes in Next.js.
- Not suitable for platforms like Cloudflare, which rely on Edge Computing.

#### Edge Runtime:
- Runs at the edge of the network, providing faster, globally distributed response times for users.
- Required for platforms like Cloudflare Pages, which don’t support the full Node.js Runtime, making the Edge Runtime essential for handling dynamic routes (e.g., 404 pages) or server-side functionality.
- Best suited for lightweight tasks such as notFound() in Next.js, which can be executed more efficiently on the edge without the overhead of a full Node.js server.
- Enhances performance on static or serverless hosting platforms, improving scalability and reducing latency for dynamic content.

References:
- https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes
- https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes

---

GitHub issues: #53 

404 preview page: https://c7e72d9d.qing-bccs-club.pages.dev/404