### PR TITLE
Fix bug: personalWebsiteUrl-bug

### DIFF
--- a/frontend/app/ui/portal/team/ClubDevelopersSection.tsx
+++ b/frontend/app/ui/portal/team/ClubDevelopersSection.tsx
@@ -9,7 +9,17 @@ import tempPic from '../../../images/team/club-developers/avatar.jpg';
 import axelmejiaPic from '../../../images/team/club-developers/axel-mejia.jpg';
 import andrewLiPic from '../../../images/team/club-developers/andrew-li.jpg'
 
-const members = [
+interface Member {
+  name: string;
+  role: string;
+  photo: any;
+  linkedinUrl?: string; // Optional field
+  githubUrl?: string; // Optional field
+  personalWebsiteUrl?: string; // Optional field
+  instagramUrl?: string; // Optional field
+}
+
+const members: Member[] = [
   {
     name: 'Axel Mejia',
     role: 'Backend Developer',


### PR DESCRIPTION
TypeScript type update: set the `personalWebsiteUrl` is optional in the type definition.

Closes #76 