### PR TITLE
Bug/fix long url

### DIFF
--- a/frontend/app/(portal)/events/[event]/page.tsx
+++ b/frontend/app/(portal)/events/[event]/page.tsx
@@ -1,35 +1,32 @@
 "use client"; // This makes it a Client Component
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation'; // For navigation
-import { useSearchParams } from 'next/navigation';
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation"; // For navigation
+import { useSearchParams } from "next/navigation";
 import EventSection from "@/app/ui/portal/events/EventSection";
 
-export const runtime = 'edge';
+export const runtime = "edge";
 
 export default function Page() {
-
   const searchParams = useSearchParams();
   const [event, setEvent] = useState(null);
 
   useEffect(() => {
-    const eventParam = searchParams.get('info');
-    if (eventParam) {
+    const eventDetails = sessionStorage.getItem("eventDetails");
+    if (eventDetails) {
       try {
-        setEvent(JSON.parse(decodeURIComponent(eventParam)));
+        setEvent(JSON.parse(eventDetails));
       } catch (error) {
-        console.error('Failed to parse event object:', error);
+        console.error("Failed to parse event object:", error);
       }
     }
-  }, [searchParams]);
-  
+  }, []);
+
   const router = useRouter(); // Initialize useRouter for navigation
-  
+
   return (
     <main>
-      {event != null && (
-        <EventSection event={event} />
-      )}
+      {event != null && <EventSection event={event} />}
       <div className="mt-10 flex justify-center items-center gap-x-6">
         <a
           href="/events"

--- a/frontend/app/(portal)/events/page.tsx
+++ b/frontend/app/(portal)/events/page.tsx
@@ -1,10 +1,10 @@
 "use client"; // This makes it a Client Component
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation'; // For navigation
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation"; // For navigation
 import HeroSection from "@/app/ui/portal/events/HeroSection";
 import CalendarSection from "@/app/ui/portal/events/CalendarSection";
-import { Event } from '@/app/utils/types';
+import { Event } from "@/app/utils/types";
 
 export default function Page() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -14,66 +14,79 @@ export default function Page() {
   useEffect(() => {
     setEvents([
       {
-        title: 'Club Hours',
-        description: 'Weekly club meeting to discuss ongoing projects, coding, and collaboration.',
-        location: 'Room 0317, Ingersoll Hall',
+        title: "Club Hours",
+        description:
+          "Weekly club meeting to discuss ongoing projects, coding, and collaboration.",
+        location: "Room 0317, Ingersoll Hall",
         rrule: {
-          freq: 'weekly', // Recurring every week
-          interval: 1,    // Every week
-          byweekday: 'TU', // Tuesday
-          dtstart: '2024-09-03T13:00:00', // Start time in UTC (01:00 PM local time)
-          until: '2024-10-31', // Until the end of the year
+          freq: "weekly", // Recurring every week
+          interval: 1, // Every week
+          byweekday: "TU", // Tuesday
+          dtstart: "2024-09-03T13:00:00", // Start time in UTC (01:00 PM local time)
+          until: "2024-10-31", // Until the end of the year
         },
-        duration: '02:30', // Duration (2 hours and 30 minutes)
+        duration: "02:30", // Duration (2 hours and 30 minutes)
         exdate: [
-          '2024-10-08T13:00:00', // Exclude October 8, 2024
+          "2024-10-08T13:00:00", // Exclude October 8, 2024
         ],
       },
       {
-        title: 'Club Hours',
-        description: 'Weekly club meeting to discuss ongoing projects, coding, and collaboration.',
-        location: 'Room 0317, Ingersoll Hall',
+        title: "Club Hours",
+        description:
+          "Weekly club meeting to discuss ongoing projects, coding, and collaboration.",
+        location: "Room 0317, Ingersoll Hall",
         rrule: {
-          freq: 'weekly', // Recurring every week
-          interval: 1,    // Every week
-          byweekday: 'WE', // Wednesday
-          dtstart: '2024-09-04T12:00:00', // Start time in UTC (12:00 PM local time)
-          until: '2024-10-31', // Until the end of the year
+          freq: "weekly", // Recurring every week
+          interval: 1, // Every week
+          byweekday: "WE", // Wednesday
+          dtstart: "2024-09-04T12:00:00", // Start time in UTC (12:00 PM local time)
+          until: "2024-10-31", // Until the end of the year
         },
-        duration: '02:00', // Duration (2 hours)
+        duration: "02:00", // Duration (2 hours)
         exdate: [
-          '2024-10-02T12:00:00', // Exclude October 2, 2024
+          "2024-10-02T12:00:00", // Exclude October 2, 2024
         ],
       },
       {
-        title: 'Club Connection & Career Panel',
-        description: 'Get to know the executive board members and hear from 4 panelists about their experiences in the tech industry.',
-        location: 'Jefferson Williams 4th Fl, Student Center',
-        start: '2024-10-08T01:00:00', 
-        end: '2024-10-08T14:30:00',
+        title: "Club Connection & Career Panel",
+        description:
+          "Get to know the executive board members and hear from 4 panelists about their experiences in the tech industry.",
+        location: "Jefferson Williams 4th Fl, Student Center",
+        start: "2024-10-08T01:00:00",
+        end: "2024-10-08T14:30:00",
       },
       {
-        title: 'Virtual Career Panel',
-        description: 'Get to know and hear from 5 BC alumni and previous e-board members about their experiences in the tech industry.',
-        location: 'Virtual, RVSP for Zoom link: https://qr-code.click/i/670f06f119cc7',
-        start: '2024-10-19T05:00:00', 
-        end: '2024-10-19T06:00:00',
+        title: "Virtual Career Panel",
+        description:
+          "Get to know and hear from 5 BC alumni and previous e-board members about their experiences in the tech industry.",
+        location:
+          "Virtual, RVSP for Zoom link: https://qr-code.click/i/670f06f119cc7",
+        start: "2024-10-19T05:00:00",
+        end: "2024-10-19T06:00:00",
       },
     ]);
   }, []);
 
   // Event click handler to navigate to the specific event page
   const handleEventClick = (clickInfo: any) => {
-    const eventId = clickInfo.event.title.replace(" ", ""); // Get the event ID
-    router.push(`/events/${eventId}?info=${encodeURIComponent(JSON.stringify(clickInfo.event))}`); // Navigate to /events/[eventId] with event details
+    const eventId = clickInfo.event.title.replace(/\s+/g, "-"); // Replace space with dash
+    const eventDate = new Date(clickInfo.event.start)
+      .toISOString()
+      .split("T")[0]; // Extract event date in year-month-day format
+
+    // Store the full event information in sessionStorage
+    sessionStorage.setItem("eventDetails", JSON.stringify(clickInfo.event));
+
+    // Navigate to events page
+    router.push(`/events/${eventId}-${eventDate}`);
   };
 
   return (
     <main>
       <HeroSection />
-      {events.length > 0 && 
-        (<CalendarSection handleEventClick={handleEventClick} events={events}/>)
-      }
+      {events.length > 0 && (
+        <CalendarSection handleEventClick={handleEventClick} events={events} />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
I used sessionStorage to store all the event data without having to pass all the information in the URL. This method only requires changing and updating a few lines and keeps the events URL short. I believe this is the better approach than using redux like Kevin suggested.

My change:
<img width="1688" alt="Screenshot 2024-10-23 at 2 10 52 AM" src="https://github.com/user-attachments/assets/19920dad-9f5a-4d5c-9a89-5418981ff7c8">

Club website:
<img width="1688" alt="Screenshot 2024-10-23 at 2 10 58 AM" src="https://github.com/user-attachments/assets/6017bce3-9d38-434d-84bd-c250d9a9f9f3">

